### PR TITLE
Fix: Text inside DOM does not show up when written in same line.

### DIFF
--- a/lib/haml2slim/converter.rb
+++ b/lib/haml2slim/converter.rb
@@ -45,13 +45,13 @@ module Haml2Slim
     def parse_tag(tag_line)
       tag_line.sub!(/^%/, '')
 
-      if tag_line_contains_attr = tag_line.match(/(.+)\{(.+)\}/)
-        tag, attrs = *tag_line_contains_attr[1..2]
+      if tag_line_contains_attr = tag_line.match(/(.+)\{(.+)\}(.+)/)
+        tag, attrs, text = *tag_line_contains_attr[1..3]
 
         attrs.gsub!(/,?( ?):?"?([^"'{ ]+)"? ?=> ?/, '\1\2=')
         attrs.gsub!(/=([^"']+)(?: |$)/, '=(\1)')
 
-        "#{tag} #{attrs}"
+        "#{tag} #{attrs} #{text}"
       else
         tag_line
       end


### PR DESCRIPTION
Lines like this: < a href="javascript:void(0)"> text is here < /a> get converted as a href="javascript:void(0)".
Fixed this in the regex
