### PR TITLE
Add stdin/stdout support

### DIFF
--- a/lib/haml2slim/command.rb
+++ b/lib/haml2slim/command.rb
@@ -51,6 +51,8 @@ module Haml2Slim
       @options[:input]  = file        = args.shift
       @options[:output] = destination = args.shift
 
+      @options[:input] = file = "-" unless file
+
       if File.directory?(@options[:input])
         Dir["#{@options[:input]}/**/*.haml"].each { |file| _process(file, destination) }
       else
@@ -71,8 +73,14 @@ module Haml2Slim
         slim_file = destination || slim_file
       end
 
-      @options[:output] = file ? File.open(slim_file, 'w') : $stdout
-      @options[:output].puts Haml2Slim.convert!(File.open(file, 'r'))
+      in_file = if @options[:input] == "-"
+                  $stdin
+                else
+                  File.open(file, 'r')
+                end
+
+      @options[:output] = slim_file && slim_file != '-' ? File.open(slim_file, 'w') : $stdout
+      @options[:output].puts Haml2Slim.convert!(in_file)
       @options[:output].close
 
       File.delete(file) if @options[:delete]

--- a/test/test_haml2slim.rb
+++ b/test/test_haml2slim.rb
@@ -28,6 +28,26 @@ class TestHaml2Slim < MiniTest::Unit::TestCase
     assert_equal true, slim_file?(slim_path)
   end
 
+  def test_convert_file_to_stdout
+    File.open(haml_file, "w") do |f|
+      f.puts "%p\n  %h1 Hello"
+    end
+
+    IO.popen("bin/haml2slim #{haml_file} -", "r") do |f|
+      assert_equal "p\n  h1 Hello\n", f.read
+    end
+  end
+
+  def test_convert_stdin_to_stdout
+    File.open(haml_file, "w") do |f|
+      f.puts "%p\n  %h1 Hello"
+    end
+
+    IO.popen("cat #{haml_file} | bin/haml2slim", "r") do |f|
+      assert_equal "p\n  h1 Hello\n", f.read
+    end
+  end
+
   def test_convert_directory
     `bin/haml2slim #{tmp_dir}`
     assert_equal true, slim_file?


### PR DESCRIPTION
Hi, I added stdin and stdout support for haml2slim, usage is as follows:

``` bash
haml2slim /path/to/file.slim - # writes to stdout
```

``` bash
cat /path/to/file.slim | haml2slim # reads from stdin and writes to stdout
```

What do you think about it?

PS I had trouble running tests for ruby-1.9.2/slim-1.0.3, I made sure my new tests do pass
