### PR TITLE
handle !!! doctype

### DIFF
--- a/lib/haml2slim/converter.rb
+++ b/lib/haml2slim/converter.rb
@@ -27,7 +27,7 @@ module Haml2Slim
           case line[0]
             when ?%, ?., ?# then parse_tag(line)
             when ?:         then "#{line[1..-1]}:"
-            when ?!         then line.sub(/^!!!/, 'doctype')
+            when ?!         then line == "!!!" ? line.sub(/^!!!/, 'doctype html') : line.sub(/^!!!/, 'doctype') 
             when ?-, ?=     then line
             when ?~         then line.sub(/^~/, '=')
             when ?/         then line.sub(/^\//, '/!')


### PR DESCRIPTION
When haml doctype is only '!!!' it generates 'doctype', which is not valid slim doctype
