### PR TITLE
Support new 1.9 hash syntax

### DIFF
--- a/lib/haml2slim/converter.rb
+++ b/lib/haml2slim/converter.rb
@@ -72,6 +72,13 @@ module Haml2Slim
         wrapped_value = value.to_s =~ /\s+/ ? "(#{value})" : value
         "#{space}#{key_prefix}#{key}=#{wrapped_value}"
       end
+      attrs.gsub!(/,?( ?)"?([^"'{ ]+)"?:\s*([^,]*)/) do
+        space = $1
+        key = $2
+        value = $3
+        wrapped_value = value.to_s =~ /\s+/ ? "(#{value})" : value
+        "#{space}#{key_prefix}#{key}=#{wrapped_value}"
+      end
       data_temp.each do |k, v|
         attrs.gsub!("#{k}=#{k}", v)
       end

--- a/lib/haml2slim/converter.rb
+++ b/lib/haml2slim/converter.rb
@@ -65,19 +65,17 @@ module Haml2Slim
         data_temp[key] = parse_attrs($1, 'data-')
         ":#{key} => #{key}"
       end
-      attrs.gsub!(/,?( ?):?"?([^"'{ ]+)"?\s*=>\s*([^,]*)/) do
-        space = $1
-        key = $2
-        value = $3
-        wrapped_value = value.to_s =~ /\s+/ ? "(#{value})" : value
-        "#{space}#{key_prefix}#{key}=#{wrapped_value}"
-      end
-      attrs.gsub!(/,?( ?)"?([^"'{ ]+)"?:\s*([^,]*)/) do
-        space = $1
-        key = $2
-        value = $3
-        wrapped_value = value.to_s =~ /\s+/ ? "(#{value})" : value
-        "#{space}#{key_prefix}#{key}=#{wrapped_value}"
+      [
+        /,?( ?):?"?([^"'{ ]+)"?\s*=>\s*([^,]*)/, 
+        /,?( ?)"?([^"'{ ]+)"?:\s*([^,]*)/
+      ].each do |regexp|
+        attrs.gsub!(regexp) do
+          space = $1
+          key = $2
+          value = $3
+          wrapped_value = value.to_s =~ /\s+/ ? "(#{value})" : value
+          "#{space}#{key_prefix}#{key}=#{wrapped_value}"
+        end
       end
       data_temp.each do |k, v|
         attrs.gsub!("#{k}=#{k}", v)

--- a/test/test_haml2slim.rb
+++ b/test/test_haml2slim.rb
@@ -76,6 +76,12 @@ class TestHaml2Slim < MiniTest::Unit::TestCase
     assert_haml_to_slim haml, slim
   end
 
+  def test_new_syntax_hash_convert
+    haml = '%a{title: 1 + 1, href: "/#{test_obj.method}", height: "50px", width: "50px"}'
+    slim = 'a title=(1 + 1) href="/#{test_obj.method}" height="50px" width="50px"'
+    assert_haml_to_slim haml, slim
+  end
+
   def test_no_html_escape_predicate
     haml = '!= method_call'
     slim = '== method_call'


### PR DESCRIPTION
Hi,

This change enables to support new Ruby 1.9 style hash syntax like below:

Haml:

``` haml
%a{title: 1 + 1, href: "/#{test_obj.method}", height: "50px", width: "50px"}
```

will be converted to Slim:

``` slim
a title=(1 + 1) href="/#{test_obj.method}" height="50px" width="50px"
```

Thanks!
